### PR TITLE
Pytorch MNIST image: Allow root group to access test folder

### DIFF
--- a/pytorch_mnist_image/Dockerfile
+++ b/pytorch_mnist_image/Dockerfile
@@ -2,7 +2,6 @@
 FROM pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime
 
 WORKDIR /test
-COPY entrypoint.sh entrypoint.sh
 
 # Install MNIST requirements
 COPY mnist_pip_requirements.txt requirements.txt
@@ -13,6 +12,10 @@ COPY mnist.py mnist.py
 COPY download_dataset.py download_dataset.py
 RUN torchrun download_dataset.py
 
-USER 65532:65532
-WORKDIR /workdir
+# Allow root group to access test folder
+RUN chgrp -R 0 /test && \
+    chmod -R g+rwX /test
+
+USER 65532:0
+COPY entrypoint.sh entrypoint.sh
 ENTRYPOINT ["/test/entrypoint.sh"]


### PR DESCRIPTION
Needed for compatibility with OpenShift.

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Adjusted permissions for test folder to be available for root group. Adding default user to the root group.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->